### PR TITLE
Add multi-arch support

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,73 +1,136 @@
-env:
-  DOCKER_HUB_REPO: 'forumone/gesso'
-
-# Consolidate the common configuration for reuse across multiple steps.
 definitions:
-  # Configure some default step values.
-  step-defaults: &step-defaults
-    timeout_in_minutes: 15
-  matrix-setup: &matrix-setup
+  is-feature: &is-feature >-
+    build.branch != "main"
+    || build.pull_request.id != null
+
+  is-release: &is-release >-
+    build.branch == "main"
+    && build.pull_request.id == null
+
+  matrix: &matrix
     setup:
       php:
         - "8.3"
         - "8.2"
         - "8.1"
         - "8.0"
-      node_version:
-        - "14"
-        - "16"
-        - "18"
+      node:
         - "20"
-  docker-build: &docker-build
-    "docker build -f Dockerfile -t $DOCKER_HUB_REPO:node-v{{matrix.node_version}}-php-{{matrix.php}} --build-arg PHP_VERSION={{matrix.php}} --build-arg NODE_VERSION={{matrix.node_version}} ."
-  docker-push: &docker-push
-    "docker push $DOCKER_HUB_REPO:node-v{{matrix.node_version}}-php-{{matrix.php}}"
-  queues:
-    # Docker-based tasks should run in the Docker queue.
-    docker-agents: &docker-agents
-      agents:
-        queue: "docker-builders"
-  plugins:
-    seek: &seek
-      seek-oss/aws-sm#v2.0.0:
-        env:
-          DOCKER_LOGIN_PASSWORD: buildkite/dockerhubid
-    docker-login: &docker-login
-      docker-login#v2.0.1:
-        username: f1builder
-        password-env: DOCKER_LOGIN_PASSWORD
+        - "18"
+        - "16"
+        - "14"
+
+  agents-amd64: &agents-amd64
+    queue: docker-builders
+
+  agents-arm64: &agents-arm64
+    queue: docker-builders-arm
+
+  docker-password: &docker-password
+    seek-oss/aws-sm#v2.3.3:
+      env:
+        F1BUILDER_DOCKER_PASSWORD: forumone/docker-hub
+
+  docker-login: &docker-login
+    docker-login#v3.0.0:
+      username: f1builder
+      password-env: F1BUILDER_DOCKER_PASSWORD
 
 steps:
-  - label: ":pipeline: Build :php: node-v{{matrix.node_version}}-php-{{matrix.php}}"
-    <<: *docker-agents
-    concurrency_group: $BUILDKITE_PIPELINE_SLUG/docker
-    concurrency: 4
-    retry:
-      automatic:
-        - exit_status: -1
-          limit: 2
-    branches:
-      - "!main"
-    command:
-      - *docker-build
-    matrix:
-      <<: *matrix-setup
+  # Feature steps: build and discard images
+  - group: ":docker: Feature build (amd64)"
+    steps:
+      - label: "Build :node: {{matrix.node}} + :php: {{matrix.php}} (amd64)"
+        matrix: *matrix
+        agents: *agents-amd64
+        if: *is-feature
 
-  - label: ":pipeline: Deploy :php: {{matrix.gesso_version}}-node-v{{matrix.node_version}}-php-{{matrix.php}}"
-    <<: *docker-agents
-    concurrency_group: $BUILDKITE_PIPELINE_SLUG/docker
-    concurrency: 4
-    plugins:
-      <<: *seek
-      <<: *docker-login
-    branches:
-      - main
-    retry:
-      automatic:
-        - exit_status: -1
-          limit: 2
-    command:
-      - *docker-build
-      - *docker-push
-    matrix:
-      <<: *matrix-setup
+        concurrency: 4
+        concurrency_group: $BUILDKITE_PIPELINE_SLUG/amd64
+
+        command: >-
+          docker buildx build .
+          --progress=plain
+          --output=type=tar,dest=/dev/null
+          --build-arg=PHP_VERSION={{matrix.php}}
+          --build-arg=NODE_VERSION={{matrix.node}}
+
+  - group: ":docker: Feature build (arm64)"
+    steps:
+      - label: "Build :node: {{matrix.node}} + :php: {{matrix.php}} (arm64)"
+        matrix: *matrix
+        agents: *agents-arm64
+        if: *is-feature
+
+        concurrency: 4
+        concurrency_group: $BUILDKITE_PIPELINE_SLUG/arm64
+
+        command: >-
+          docker buildx build .
+          --progress=plain
+          --output=type=tar,dest=/dev/null
+          --build-arg=PHP_VERSION={{matrix.php}}
+          --build-arg=NODE_VERSION={{matrix.node}}
+
+  # Production steps: build and push images, then manually create multi-arch manifests
+  - group: ":docker: Build and push (amd64)"
+    steps:
+      - label: "Build :node: {{matrix.node}} + :php: {{matrix.php}} (amd64)"
+        matrix: *matrix
+        agents: *agents-amd64
+        if: *is-release
+
+        concurrency: 4
+        concurrency_group: $BUILDKITE_PIPELINE_SLUG/amd64
+
+        plugins: [*docker-password, *docker-login]
+        commands:
+          - >-
+            docker buildx build .
+            --progress=plain
+            --output=type=docker
+            --tag=forumone/gesso:node-v{{matrix.node}}-php-{{matrix.php}}-amd64
+            --build-arg=PHP_VERSION={{matrix.php}}
+            --build-arg=NODE_VERSION={{matrix.node}}
+          - docker push forumone/gesso:node-v{{matrix.node}}-php-{{matrix.php}}-amd64
+
+  - group: ":docker: Build and push (arm64)"
+    steps:
+      - label: "Build :node: {{matrix.node}} + :php: {{matrix.php}} (arm64)"
+        matrix: *matrix
+        agents: *agents-arm64
+        if: *is-release
+
+        concurrency: 4
+        concurrency_group: $BUILDKITE_PIPELINE_SLUG/arm64
+
+        plugins: [*docker-password, *docker-login]
+        commands:
+          - >-
+            docker buildx build .
+            --progress=plain
+            --output=type=docker
+            --tag=forumone/gesso:node-v{{matrix.node}}-php-{{matrix.php}}-arm64
+            --build-arg=PHP_VERSION={{matrix.php}}
+            --build-arg=NODE_VERSION={{matrix.node}}
+          - docker push forumone/gesso:node-v{{matrix.node}}-php-{{matrix.php}}-arm64
+
+  - wait: ~
+
+  - group: ":docker: Assemble manifests"
+    steps:
+      - label: ":docker: Assemble :node: {{matrix.node}} + :php: {{matrix.php}}"
+        matrix: *matrix
+        if: *is-release
+
+        concurrency: 4
+        concurrency_group: $BUILDKITE_PIPELINE_SLUG/manifest
+
+        plugins: [*docker-password, *docker-login]
+        commands:
+          - >-
+            docker manifest create
+            forumone/gesso:node-v{{matrix.node}}-php-{{matrix.php}}
+            forumone/gesso:node-v{{matrix.node}}-php-{{matrix.php}}-amd64
+            forumone/gesso:node-v{{matrix.node}}-php-{{matrix.php}}-arm64
+          - docker manifest push forumone/gesso:node-v{{matrix.node}}-php-{{matrix.php}}

--- a/README.md
+++ b/README.md
@@ -2,100 +2,21 @@
 
 This image is intended to be used as a base for building [Gesso](https://github.com/forumone/gesso/). For local development, the project's sources can be bind-mounted. During production builds, this image is meant to be used as part of a multi-stage build.
 
-With the new release of Gesso 5. As of Jan 19, 2023, gesso switched from using `alpine` as the base linux distro to use `buster`. That is the primary difference from the gesso images from using the `4` tag to `5`.
+## Tags
 
-## Tags and Included Tools
-
-### Gesso 3, 4, and 5
-
-Image tags for Gesso 3, 4, and 5 are derived from a set of the following components:
-
-#### Node Version
-
-* 12
-* 14
-* 16
-* 18
-
-#### PHP Version
-
-* 7.4
-* 8.0
-* 8.1
-* 8.2
-
-#### Gesso Version
-
-* 3
-* 4
-* 5
-
-#### No longer getting updates
-
-* Node version: 10, 12, 14
+* Supported Node.js versions: 20, 18, 16, 14
+* Supported PHP versions: 8.3, 8.2, 8.1, 8.0
 
 These components are used to derive the image tag thusly:
 
-`forumone/gesso:node-v{node-version}-php-{php-version}`
+`forumone/gesso:node-v${NODE_VERSION}-php-${PHP_VERSION}`
 
-For instance an image with  Node 18, and php 8.2 would have the following image tag:
+For instance an image with Node.js 18, and PHP 8.2 would have the following image tag: `forumone/gesso:node-v18-php-8.2`
 
-`forumone/gesso:node-v18-php-8.2`
+## Included Tools
 
-### Gesso 2
+In addition to the included npm and yarn package managers, we globally install the following:
 
-We provide a large number of images for Gesso 2.x due to the increased variation in configurations.
-
-| Node Version | PHP Version | Image                             |
-|--------------|-------------|-----------------------------------|
-| v4           | 5.6         | forumone/gesso:2-node-v4-php-5.6  |
-| v4           | 7.0         | forumone/gesso:2-node-v4-php-7.0  |
-| v4           | 7.1         | forumone/gesso:2-node-v4-php-7.1  |
-| v4           | 7.2         | forumone/gesso:2-node-v4-php-7.2  |
-| v4           | 7.3         | forumone/gesso:2-node-v4-php-7.3  |
-| v4           | 7.4         | forumone/gesso:2-node-v4-php-7.4  |
-| v4           | 8.0         | forumone/gesso:2-node-v4-php-8.0  |
-| v6           | 5.6         | forumone/gesso:2-node-v6-php-5.6  |
-| v6           | 7.0         | forumone/gesso:2-node-v6-php-7.0  |
-| v6           | 7.1         | forumone/gesso:2-node-v6-php-7.1  |
-| v6           | 7.2         | forumone/gesso:2-node-v6-php-7.2  |
-| v6           | 7.3         | forumone/gesso:2-node-v6-php-7.3  |
-| v6           | 7.4         | forumone/gesso:2-node-v6-php-7.4  |
-| v6           | 8.1         | forumone/gesso:2-node-v6-php-8.0  |
-| v8           | 5.6         | forumone/gesso:2-node-v8-php-5.6  |
-| v8           | 7.0         | forumone/gesso:2-node-v8-php-7.0  |
-| v8           | 7.1         | forumone/gesso:2-node-v8-php-7.1  |
-| v8           | 7.2         | forumone/gesso:2-node-v8-php-7.2  |
-| v8           | 7.3         | forumone/gesso:2-node-v8-php-7.3  |
-| v8           | 7.4         | forumone/gesso:2-node-v8-php-7.4  |
-| v8           | 8.0         | forumone/gesso:2-node-v8-php-8.0  |
-| v10          | 5.6         | forumone/gesso:2-node-v10-php-5.6 |
-| v10          | 7.0         | forumone/gesso:2-node-v10-php-7.0 |
-| v10          | 7.1         | forumone/gesso:2-node-v10-php-7.1 |
-| v10          | 7.2         | forumone/gesso:2-node-v10-php-7.2 |
-| v10          | 7.3         | forumone/gesso:2-node-v10-php-7.3 |
-| v10          | 7.4         | forumone/gesso:2-node-v10-php-7.4 |
-| v10          | 8.0         | forumone/gesso:2-node-v10-php-8.0 |
-| v12          | 5.6         | forumone/gesso:2-node-v12-php-5.6 |
-| v12          | 7.0         | forumone/gesso:2-node-v12-php-7.0 |
-| v12          | 7.1         | forumone/gesso:2-node-v12-php-7.1 |
-| v12          | 7.2         | forumone/gesso:2-node-v12-php-7.2 |
-| v12          | 7.3         | forumone/gesso:2-node-v12-php-7.3 |
-| v12          | 7.4         | forumone/gesso:2-node-v12-php-7.4 |
-| v12          | 8.0         | forumone/gesso:2-node-v12-php-8.0 |
-| v14          | 5.6         | forumone/gesso:2-node-v14-php-5.6 |
-| v14          | 7.0         | forumone/gesso:2-node-v14-php-7.0 |
-| v14          | 7.1         | forumone/gesso:2-node-v14-php-7.1 |
-| v14          | 7.2         | forumone/gesso:2-node-v14-php-7.2 |
-| v14          | 7.3         | forumone/gesso:2-node-v14-php-7.3 |
-| v14          | 7.4         | forumone/gesso:2-node-v14-php-7.4 |
-| v14          | 8.0         | forumone/gesso:2-node-v14-php-8.0 |
-
-*NOTE:*  php version 8.1 will be added later for gesso:2 tags.
-
-## Source
-
-Images here are built from two repositories:
-
-* Gesso 3.x & 4.x uses [forumone/docker-gesso](https://github.com/forumone/docker-gesso) on GitHub.
-* Gesso 2.x uses [forumone/docker-f1ux](https://github.com/forumone/docker-f1ux) on GitHub.
+* `envinfo`
+* `gulp-cli`
+* `pm2`


### PR DESCRIPTION
Changes made in this PR:

1. The Buildkite pipeline has been rewritten to take advantage of new multi-arch support. Individual architecture images are built separately and then assembled into a multi-arch manifest.
2. The README has bean cleaned up to remove superfluous information.