### PR TITLE
fix: Changes Docker image dependency and target PHP versions

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -10,16 +10,15 @@ definitions:
   matrix: &matrix
     setup:
       php:
-        - "8.3"
-        - "8.2"
         - "8.1"
-        - "8.0"
+        - "8.2"
+        - "8.3"
       node:
-        - "22"
-        - "20"
-        - "18"
         - "16"
-        - "14"
+        - "18"
+        - "20"
+        - "22"
+        - "24"
 
   agents-amd64: &agents-amd64
     queue: docker-builders

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,20 @@
+06/02/2025
+----------
+- Changes the base PHP image to be the Forum One php-cli image.
+  - Updates the image to no use `bookworm` instead of `bullseye`.
+- Updates the `Dockerfile` to reduce build times and image sizes.
+- Drops on-going support for PHP 8.0.
+- Drops on-going support for NodeJS 14.
+- Adds support for NodeJS 24.
+- Drops no longer supported Python 2.
+
+01/28/2025
+----------
+* Added `node 22`
+
 03/19/2024
 ----------
-* Removed pacakage: `python2`
+* Removed package: `python2`
 * Updated from `buster` to `bullseye`
   * This was changed since `buster` is going EOL in June
 * Added `php 8.3`

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,34 +1,37 @@
 ARG NODE_VERSION
 ARG PHP_VERSION
 
-FROM node:${NODE_VERSION}-bullseye as nodeJs
+FROM node:${NODE_VERSION}-bookworm as nodeJs
 
 USER root
 
 RUN chown -R root:root /opt
 
-FROM php:${PHP_VERSION}-cli-bullseye
+FROM public.ecr.aws/forumone/php-cli:${PHP_VERSION}
 
-## This is needed forhte time being since node module: fiber is being used in gesso
+## This is needed for the time being since node module: fiber is being used in gesso
 ## https://github.com/forumone/gesso/issues/626
-#
-RUN apt update
-RUN apt install -y python3 python2
+# Base persistent dependencies
+RUN set -eux \
+  && apt-get update \
+  && apt-get install -y --no-install-recommends \
+    python3 \
+  && rm -rf /var/lib/apt/lists/*
 
-
-# Instead of building node from source, just pulling a compiled version already
+# Instead of building NodeKS from source, just pulling a compiled version already.
 COPY --from=nodeJs /usr/local/bin/node /usr/local/bin/node
 COPY --from=nodeJs /usr/local/lib/node_modules /usr/local/lib/node_modules
 COPY --from=nodeJs /opt /opt
 
-# Making the correct symlinks needed for node
-RUN ln -s ../lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm
-RUN ln -s ../lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx
-RUN ln -s /opt/*/bin/yarn /usr/local/bin/yarn
-RUN ln -s /opt/*/bin/yarnpkg /usr/local/bin/yarnpkg
+# Making the correct symlinks needed for NodeJS.
+RUN set -eux \
+  && ln -s ../lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm \
+  && ln -s ../lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx \
+  && ln -s /opt/*/bin/yarn /usr/local/bin/yarn \
+  && ln -s /opt/*/bin/yarnpkg /usr/local/bin/yarnpkg
 
+# Install required global NPM packages.
 RUN npm i -g envinfo gulp-cli pm2
-
 
 # Default working directory to /app - this gives folks a predicable location for builds
 # and artifacts.

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ This image is intended to be used as a base for building [Gesso](https://github.
 
 ## Tags
 
-* Supported Node.js versions: 22, 20, 18, 16, 14
-* Supported PHP versions: 8.3, 8.2, 8.1, 8.0
+* Supported Node.js versions: 24, 22, 20, 18, 16, 14
+* Supported PHP versions: 8.3, 8.2, 8.1
 
 These components are used to derive the image tag thusly:
 


### PR DESCRIPTION
- Changes the base PHP image to be the Forum One php-cli image.
  - Updates the image to no use `bookworm` instead of `bullseye`.
- Updates the `Dockerfile` to reduce build times and image sizes.
- Drops on-going support for PHP 8.0.
- Drops on-going support for NodeJS 14.
- Adds support for NodeJS 24.
- Drops no longer supported Python 2.

Replaces: https://github.com/forumone/docker-gesso/pull/25